### PR TITLE
Fix hellish cache deadlock

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -196,7 +196,7 @@ pub(crate) async fn update_guild_commands(
     }
 }
 
-#[tracing::instrument("Handling application command invocation")]
+#[tracing::instrument("Handling application command invocation", skip(state))]
 pub(crate) async fn handle_command(state: crate::State, cmd: &ApplicationCommand) -> Result<()> {
     tracing::debug!(?cmd.data.id, ?state.cmd_states, "Executing command");
     if cmd.guild_id.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,12 @@ fn validate_configs() -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let rt = tokio::runtime::Builder::new_current_thread().worker_threads(1).max_blocking_threads(1).enable_all().build().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .worker_threads(1)
+        .max_blocking_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
     rt.block_on(real_main())?;
     Ok(())
 }
@@ -605,7 +610,7 @@ async fn filter_message_edit_http(update: &MessageUpdate, state: &State) -> Resu
                 .roles
                 .iter()
                 .map(|r| *r)
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>(),
         }
     };
 
@@ -649,8 +654,8 @@ async fn filter_message_edit(update: &MessageUpdate, state: &State) -> Result<()
                             // another thread holds a reference to the cached message. Dropping
                             // the cached reference prevents this.
                             drop(message);
-                            return filter_message_edit_http(update, state).await
-                        },
+                            return filter_message_edit_http(update, state).await;
+                        }
                     }
                 }
             };


### PR DESCRIPTION
For a while now Chrysanthemum has been plagued by a deadlock in message edit filtering. I've only now had the time to sit down and figure out what's going on. Essentially, Chrysanthemum, after filtering a message edit, locks up completely, _sometimes_. The sequence of events looks something like:

- A user edits a message to something that will be filtered.
- Chrysanthemum picks up the edit and tries to gather all the information from the cache.
- If it succeeds, it holds a reference to the cached data for the duration of message filtering.
- If the message is deleted, the Discord API could respond quickly enough for the cache to be updated before the deletion HTTP request completes.
- The event loop attempts to update the cache.
- The cache is updated while holding a reference into the cache, [a scenario that can cause the underlying `dashmap` implementation to deadlock](https://docs.rs/dashmap/latest/dashmap/struct.DashMap.html#method.remove).

The fix is to clone data out of the cache, so that we don't hold a reference to it for very long. This is unfortunate for efficiency reasons, but we can live with it.