### PR TITLE
Correct invite regex

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -29,7 +29,7 @@ static_regex!(
             .unwrap()
 );
 static_regex!(
-    invite_regex = RegexBuilder::new(r"discord.gg/(\w+)")
+    invite_regex = RegexBuilder::new(r"discord.gg/([-\w]+)")
         .case_insensitive(true)
         .build()
         .unwrap()


### PR DESCRIPTION
Dashes (`-`) are currently ignored in the invite regex, causing server invites with dashes to be filtered despite being whitelisted.

e.g. If `gg/discord-developers` is whitelisted, it'll be filtered because `gg/discord` isn't